### PR TITLE
Allow for alpha to be set in SPStorkTransitioningDelegate

### DIFF
--- a/Source/SPStorkController/TransitioningDelegate/SPStorkPresentationController.swift
+++ b/Source/SPStorkController/TransitioningDelegate/SPStorkPresentationController.swift
@@ -31,6 +31,8 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
     var hideIndicatorWhenScroll: Bool = false
     var customHeight: CGFloat? = nil
     var translateForDismiss: CGFloat = 200
+    var alpha: CGFloat =  0.51
+    var cornerRadius: CGFloat = 10
     
     var transitioningDelegate: SPStorkTransitioningDelegate?
     weak var storkDelegate: SPStorkControllerDelegate?
@@ -56,9 +58,6 @@ class SPStorkPresentationController: UIPresentationController, UIGestureRecogniz
         let statusBarHeight: CGFloat = UIApplication.shared.statusBarFrame.height
         return (statusBarHeight < 25) ? 30 : statusBarHeight
     }
-    
-    private let alpha: CGFloat =  0.51
-    var cornerRadius: CGFloat = 10
     
     private var scaleForPresentingView: CGFloat {
         guard let containerView = containerView else { return 0 }

--- a/Source/SPStorkController/TransitioningDelegate/SPStorkTransitioningDelegate.swift
+++ b/Source/SPStorkController/TransitioningDelegate/SPStorkTransitioningDelegate.swift
@@ -32,6 +32,7 @@ public final class SPStorkTransitioningDelegate: NSObject, UIViewControllerTrans
     public var customHeight: CGFloat? = nil
     public var translateForDismiss: CGFloat = 200
     public var cornerRadius: CGFloat = 10
+    public var alpha: CGFloat = 0.51
     public weak var storkDelegate: SPStorkControllerDelegate? = nil
     
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
@@ -45,6 +46,7 @@ public final class SPStorkTransitioningDelegate: NSObject, UIViewControllerTrans
         controller.customHeight = self.customHeight
         controller.translateForDismiss = self.translateForDismiss
         controller.cornerRadius = self.cornerRadius
+        controller.alpha = self.alpha
         controller.transitioningDelegate = self
         controller.storkDelegate = self.storkDelegate
         return controller


### PR DESCRIPTION
Similar to how cornerRadius or customHeight is set. I need this for my current implementation as the controller in the background is too visually distracting.